### PR TITLE
Update progress statuses for new data

### DIFF
--- a/CIFProgressStatus.py
+++ b/CIFProgressStatus.py
@@ -73,28 +73,25 @@ def update_progress_status(progress_dict, indicator_id):
     write_meta_md(meta, indicator_id)
     
 
-# indicator_ids = get_indicator_ids()
+indicator_ids = get_indicator_ids()
 
 # TODO: if auto prog is OFF, shouldn't calculate!!!!!!!!!
-# for ind_id in indicator_ids:
-#     # Uncomment to turn on ALL indicator calculation
-#     # turn_on_progress_calc(ind_id)
-#
-#     # Get data + metadata for calculation
-#     indicator = merge_indicator(ind_id)
-#     if indicator is not None:
-#         # Run data + metadata through calculation to get progress
-#         progress = pm.measure_indicator_progress(indicator)
-#
-#         if progress is None:
-#             progress = 'not_available'
-#
-#         print(ind_id + ': ' + progress)
-#
-#         # Update progress status field in meta
-#         progress_dict = {'progress_status': progress}
-#         # update_progress_status(progress_dict, ind_id)
-#         print(progress_dict)
+for ind_id in indicator_ids:
+    # Uncomment to turn on ALL indicator calculation
+    # turn_on_progress_calc(ind_id)
+
+    # Get data + metadata for calculation
+    indicator = merge_indicator(ind_id)
+    if indicator is not None:
+        # Run data + metadata through calculation to get progress
+        progress = pm.measure_indicator_progress(indicator)
+        if progress is not None:
+            print(ind_id + ': ' + progress)
+            # Update progress status field in meta
+            progress_dict = {'progress_status': progress}
+            # Uncomment to update metadata files
+            update_progress_status(progress_dict, ind_id)
+
 
 # individal calculations result ----
 # test_ind = merge_indicator('12-2-1')

--- a/meta/15-4-1.md
+++ b/meta/15-4-1.md
@@ -58,5 +58,5 @@ source_geographical_coverage_2: Canada
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
-progress_status: moderate_progress
+progress_status: significant_deterioration
 ---

--- a/meta/16-3-1.md
+++ b/meta/16-3-1.md
@@ -47,7 +47,7 @@ data_start_values:
   value: Total violent Criminal Code violations
 
 data_non_statistical: false
-data_show_map: true
+data_show_map: false
 
 
 # Source

--- a/meta/9-3-1.md
+++ b/meta/9-3-1.md
@@ -53,7 +53,8 @@ data_show_map: true
 # Source
 
 source_active_1: true
-source_url_text_1: Canadian Radio-television and Telecommunications Commission. Current trends - High-speed broadband, 2021.
+source_url_text_1: Canadian Radio-television and Telecommunications Commission. Current
+  trends - High-speed broadband, 2021.
 source_url_1: https://crtc.gc.ca/eng/publications/reports/PolicyMonitoring/ban.htm
 source_organisation_1: Canadian Radio-television and Telecommunications Commission
 source_periodicity_1: Annual

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/dougmet/yamlmd
 git+https://github.com/open-sdg/sdg-build@2.0.0
-
+frictionless==4.40.8


### PR DESCRIPTION
ran the progress measure calculation code for CIF data updates which auto-populated any changes (seems like the only change was in the progress status of 15.4.1)

EDIT: added frictionless dependency fix
EDIT 2: removed map meta field for 16.3.1 because it was causing a build error