### PR TITLE
CIF Review - 17.1.1 review 2

### DIFF
--- a/data/indicator_17-1-1.csv
+++ b/data/indicator_17-1-1.csv
@@ -4,112 +4,100 @@
 2022,data.Pillar 3 - Data Products,83.6875
 2022,data.Pillar 4 - Data Sources,88.325
 2022,data.Pillar 5 - Data Infrastructure,100
-2022,data.SPI Overall Score,92.9225
+2022,,92.9225
 2021,data.Pillar 1 - Data Use,100
 2021,data.Pillar 2 - Data Services,93.06666667
 2021,data.Pillar 3 - Data Products,83.6875
 2021,data.Pillar 4 - Data Sources,90.35
 2021,data.Pillar 5 - Data Infrastructure,100
-2021,data.SPI Overall Score,93.42083333
+2021,,93.42083333
 2020,data.Pillar 1 - Data Use,100
 2020,data.Pillar 2 - Data Services,93.06666667
 2020,data.Pillar 3 - Data Products,67.1
 2020,data.Pillar 4 - Data Sources,82.01666667
 2020,data.Pillar 5 - Data Infrastructure,95
-2020,data.SPI Overall Score,87.43666667
+2020,,87.43666667
 2019,data.Pillar 1 - Data Use,100
 2019,data.Pillar 2 - Data Services,93.2
 2019,data.Pillar 3 - Data Products,60.0125
 2019,data.Pillar 4 - Data Sources,84.11666667
 2019,data.Pillar 5 - Data Infrastructure,100
-2019,data.SPI Overall Score,87.46583333
+2019,,87.46583333
 2018,data.Pillar 1 - Data Use,100
 2018,data.Pillar 2 - Data Services,93.2
 2018,data.Pillar 3 - Data Products,60.5375
 2018,data.Pillar 4 - Data Sources,84.11666667
 2018,data.Pillar 5 - Data Infrastructure,95
-2018,data.SPI Overall Score,86.57083333
+2018,,86.57083333
 2017,data.Pillar 1 - Data Use,100
 2017,data.Pillar 2 - Data Services,95.23333333
 2017,data.Pillar 3 - Data Products,64.14375
 2017,data.Pillar 4 - Data Sources,77.86666667
 2017,data.Pillar 5 - Data Infrastructure,95
-2017,data.SPI Overall Score,86.44875
+2017,,86.44875
 2016,data.Pillar 1 - Data Use,100
 2016,data.Pillar 2 - Data Services,95.1
 2016,data.Pillar 3 - Data Products,59.20625
 2016,data.Pillar 4 - Data Sources,82.09166667
 2016,data.Pillar 5 - Data Infrastructure,95
-2016,data.SPI Overall Score,86.27958333
+2016,,86.27958333
 2015,data.Pillar 1 - Data Use,80
 2015,data.Pillar 2 - Data Services,
 2015,data.Pillar 3 - Data Products,57.16875
 2015,data.Pillar 4 - Data Sources,
 2015,data.Pillar 5 - Data Infrastructure,
-2015,data.SPI Overall Score,
 2014,data.Pillar 1 - Data Use,60
 2014,data.Pillar 2 - Data Services,
 2014,data.Pillar 3 - Data Products,50.56875
 2014,data.Pillar 4 - Data Sources,
 2014,data.Pillar 5 - Data Infrastructure,
-2014,data.SPI Overall Score,
 2013,data.Pillar 1 - Data Use,60
 2013,data.Pillar 2 - Data Services,
 2013,data.Pillar 3 - Data Products,51.29375
 2013,data.Pillar 4 - Data Sources,
 2013,data.Pillar 5 - Data Infrastructure,
-2013,data.SPI Overall Score,
 2012,data.Pillar 1 - Data Use,60
 2012,data.Pillar 2 - Data Services,
 2012,data.Pillar 3 - Data Products,51.34375
 2012,data.Pillar 4 - Data Sources,
 2012,data.Pillar 5 - Data Infrastructure,
-2012,data.SPI Overall Score,
 2011,data.Pillar 1 - Data Use,60
 2011,data.Pillar 2 - Data Services,
 2011,data.Pillar 3 - Data Products,50.09375
 2011,data.Pillar 4 - Data Sources,
 2011,data.Pillar 5 - Data Infrastructure,
-2011,data.SPI Overall Score,
 2010,data.Pillar 1 - Data Use,60
 2010,data.Pillar 2 - Data Services,
 2010,data.Pillar 3 - Data Products,49.7
 2010,data.Pillar 4 - Data Sources,
 2010,data.Pillar 5 - Data Infrastructure,
-2010,data.SPI Overall Score,
 2009,data.Pillar 1 - Data Use,40
 2009,data.Pillar 2 - Data Services,
 2009,data.Pillar 3 - Data Products,49.9375
 2009,data.Pillar 4 - Data Sources,
 2009,data.Pillar 5 - Data Infrastructure,
-2009,data.SPI Overall Score,
 2008,data.Pillar 1 - Data Use,40
 2008,data.Pillar 2 - Data Services,
 2008,data.Pillar 3 - Data Products,49.9375
 2008,data.Pillar 4 - Data Sources,
 2008,data.Pillar 5 - Data Infrastructure,
-2008,data.SPI Overall Score,
 2007,data.Pillar 1 - Data Use,40
 2007,data.Pillar 2 - Data Services,
 2007,data.Pillar 3 - Data Products,49.70625
 2007,data.Pillar 4 - Data Sources,
 2007,data.Pillar 5 - Data Infrastructure,
-2007,data.SPI Overall Score,
 2006,data.Pillar 1 - Data Use,40
 2006,data.Pillar 2 - Data Services,
 2006,data.Pillar 3 - Data Products,49.00625
 2006,data.Pillar 4 - Data Sources,
 2006,data.Pillar 5 - Data Infrastructure,
-2006,data.SPI Overall Score,
 2005,data.Pillar 1 - Data Use,40
 2005,data.Pillar 2 - Data Services,
 2005,data.Pillar 3 - Data Products,48.85625
 2005,data.Pillar 4 - Data Sources,
 2005,data.Pillar 5 - Data Infrastructure,
-2005,data.SPI Overall Score,
 2004,data.Pillar 1 - Data Use,40
 2004,data.Pillar 2 - Data Services,
 2004,data.Pillar 3 - Data Products,
 2004,data.Pillar 4 - Data Sources,
 2004,data.Pillar 5 - Data Infrastructure,
-2004,data.SPI Overall Score,

--- a/meta/17-1-1.md
+++ b/meta/17-1-1.md
@@ -41,9 +41,6 @@ graph_limits:
   - unit: Score
     minimum: 0
     maximum: 100
-data_start_values:
-  - field: Pillar
-    value: SPI Overall Score
 
 data_non_statistical: false
 data_show_map: false

--- a/meta/fr/17-1-1.md
+++ b/meta/fr/17-1-1.md
@@ -38,9 +38,6 @@ comments_limitations: "Les scores globaux des IPS sont actuellement disponibles 
 
 graph_title: "Indicateurs de performance statistique"
 graph_type: line
-data_start_values:
-  - field: Pilier
-    value: Score global
 
 data_non_statistical: false
 data_show_map: false


### PR DESCRIPTION
- #290 
  - remove SPI overall score prior to 2016 as there is no data
  - set SPI overall score as default national aggregation level