### PR TITLE
Progress measure enhancement

### DIFF
--- a/CIFProgressStatus.py
+++ b/CIFProgressStatus.py
@@ -91,7 +91,7 @@ def update_progress_status(indicator_ids):
 
     for ind_id in indicator_ids:
 
-        print(ind_id)
+        # print(ind_id)
 
         # Get data + metadata for calculation
         indicator = merge_indicator(ind_id)
@@ -142,12 +142,13 @@ def get_goal_progress(indicator_ids):
 
 def get_progress_measure_results(indicator_ids):
     """
-    Given a list of indicators, return a dictionary with the progress measure results and calculation components.
+    Return a dictionary containing the progress measure results and calculation components
+    for each indicator in the input list (indicator_ids).
     """
     progress_results = {}
 
     for ind_id in indicator_ids:
-        print(ind_id)
+        # print(ind_id)
         indicator = merge_indicator(ind_id)
 
         meta = indicator['meta']
@@ -176,12 +177,12 @@ def get_progress_measure_results(indicator_ids):
 
 def get_scores(progress_results):
     """
-    Given dictionary of progress measure results (see get_progress_measure_results),
-    return another dictionary with the score for each indicator. 
+    Given a dictionary of progress measure results (see get_progress_measure_results),
+    return another dictionary containing the score for each indicator. 
     """
     scores = {}
     for ind_id in progress_results:
-        print(ind_id)
+        # print(ind_id)
         value = progress_results[ind_id].get('progress_calculation_value')
         if value is None:
             score = None
@@ -204,12 +205,20 @@ def get_scores(progress_results):
 
 
 def update_progress_status2(progress_results):
+    """
+    Compare progress statuses in the input dictionary (progress_results) and in metadata files. 
+    If the progress_status field in the metadata is different from the progress_status in the
+    input dictionary, update the metadata with the progress_status value from the input.
+    Return a dictionary containing a string descriptions of progress status changes.
+    """
     diffs = {}
     for ind_id in progress_results:
+        # Get old progress status from metadata file
         meta = read_meta_md(ind_id)
         old_status = meta.get('progress_status')
+        # Get calculated progress status from input dictionary
         new_status = progress_results[ind_id]['progress_status']
-        # Check if the newly calculate progress measure is different than the old one
+        # Check if the newly calculated progress measure is different from the old one
         if old_status != new_status:
             diffs[ind_id] = diff_note(old_status, new_status)
             # Update progress status field in metadata

--- a/ProgressMeasure.py
+++ b/ProgressMeasure.py
@@ -1,12 +1,14 @@
 def measure_indicator_progress(data, config):
     """Sets up all needed parameters and data for progress calculation, determines methodology for calculation,
-    and returns progress measure as an output.
+    and returns progress measure calculation result as an output.
 
     Args:
         data:
         config:
     Returns:
-        output: str. A string indicating the progress measurement for the indicator.
+        output: dict. format:   {value, progress_status, config} if progress measure calculation succeeds
+                                {progress_status} if auto_progress_calculation is turned off
+                                None if progress measure calculation fails
     """
 
     # data = indicator['data']    # get indicator data
@@ -168,16 +170,18 @@ def update_progress_thresholds(config, method):
     return config
 
 
-def data_progress_measure(data, config):
+def data_progress_measure(data, config={}):
     """Checks and filters data for indicator for which progress is being calculated.
 
     If the Year column in data contains more than 4 characters (standard year format), takes the first 4 characters.
     If data contains disaggregation columns, take only the total line data.
+    If data contains total lines for different series/units, take only the total line for the units/series chosen in config.
     Removes any NA values.
     Checks that there is enough data to calculate progress.
 
     Args:
         data: DataFrame. Indicator data for which progress is being calculated.
+        config: dict. Configuration settings used when the data contains potential headlines for different units/series.
     Returns:
         DataFrame: Data in valid format for calculating progress.
     """
@@ -300,7 +304,9 @@ def methodology_2(data, config):
 
 
 def progress_measure(indicator):
-
+    """
+    Calculate and return the progress status for an indicator.
+    """
     if indicator is None:
         return None
 
@@ -312,15 +318,7 @@ def progress_measure(indicator):
     if progress_calc is None:
         return None
 
-    value = progress_calc['value']
-    config = progress_calc['config']
-
-    if value is None:
-        output = "target_achieved"
-    else:
-        output = get_progress_status(value, config)
-
-    return output
+    return progress_calc.get('progress_status')
 
 
 def score_calculation(value, target):

--- a/ProgressMeasure.py
+++ b/ProgressMeasure.py
@@ -12,29 +12,13 @@ def measure_indicator_progress(data, config):
     # data = indicator['data']    # get indicator data
     # config = indicator['meta']  # get configurations
 
-    # checks if progress calculation is turned on
-    if 'auto_progress_calculation' in config.keys():
-
-        # checks if any inputs have been configured
-        if config['auto_progress_calculation']:
-
-            if 'progress_calculation_options' in config.keys():
-                # take manual user inputs
-                config = config['progress_calculation_options'][0]
-
-        else:
-            return None
-
-    # return None if auto progress calculation is not turned on
-    else:
+    config = get_progress_calculation_options(config)
+    if config is None:
+        # return None because progress calculations not turned on
         return None
 
-    # get calculation defaults and update with user inputs (if any)
-    config = config_defaults(config)
-
     # get relevant data to calculate progress (aggregate/total line only)
-    data = data_progress_measure(data)
-
+    data = data_progress_measure(data, config)
     if data is None:
         return None
 
@@ -142,6 +126,26 @@ def default_progress_calc_options():
         }
     )
 
+def get_progress_calculation_options(metadata):
+    """
+    Get the progress_calculation_options from metadata.
+    """
+    if metadata is None:
+        return None
+    
+    # Check if progress calculation is turned on
+    if 'auto_progress_calculation' in metadata.keys():
+        if metadata['auto_progress_calculation']:
+            # Get the user inputs for progress_calculation_options
+            if 'progress_calculation_options' in metadata.keys():
+                return config_defaults(metadata['progress_calculation_options'][0])
+            else:
+                return default_progress_calc_options()
+        else:
+            return None
+    # Return None if auto progress calculation is not turned on
+    else:
+        return None
 
 def update_progress_thresholds(config, method):
     """Checks for configured progress thresholds or updates thresholds based on methodology.

--- a/ProgressMeasure.py
+++ b/ProgressMeasure.py
@@ -12,8 +12,6 @@ def measure_indicator_progress(data, config):
     # data = indicator['data']    # get indicator data
     # config = indicator['meta']  # get configurations
 
-    # if auto_progress_calculation is False --> return {value: None, progress_status: None, config = config}
-
     if not config.get('auto_progress_calculation'):
         # If auto_progress_calculation is turned off, take progress_status from metadata if it exists or not_available otherwise.
         return {'progress_status': config.get('progress_status', 'not_available')}
@@ -132,6 +130,7 @@ def default_progress_calc_options():
         }
     )
 
+
 def get_progress_calculation_options(metadata):
     """
     Get the progress_calculation_options from metadata.
@@ -140,6 +139,7 @@ def get_progress_calculation_options(metadata):
         return config_defaults(metadata['progress_calculation_options'][0])
     else:
         return default_progress_calc_options()
+
 
 def update_progress_thresholds(config, method):
     """Checks for configured progress thresholds or updates thresholds based on methodology.
@@ -191,7 +191,7 @@ def data_progress_measure(data, config):
     cols = data.columns
     if len(cols) > 2:
         # Data has disaggregations, find headline data
-        # If units are series are given, select desired unit/series to use for progress measure calculation
+        # If units or series are given, select desired unit/series to use for progress measure calculation
         if ("Units" in cols) and ("unit" in config.keys()):
             data = data.loc[data["Units"] == config["unit"]]
         if ("Series" in cols) and ("series" in config.keys()):

--- a/R/indicator_16-5-1.R
+++ b/R/indicator_16-5-1.R
@@ -39,7 +39,7 @@ court_time <- function(data, type) {
       `Sex of accused`,
       Value = VALUE
     ) %>% 
-    mutate(Series = paste0("data.", type)) %>% 
+    mutate(Series = type) %>% 
     relocate(Series, .after = Year)
   
 }

--- a/meta/11-1-1.md
+++ b/meta/11-1-1.md
@@ -77,9 +77,12 @@ source_url_2:
   https://housing-infrastructure.canada.ca/homelessness-sans-abri/reports-rapports/data-shelter-2018-donnees-refuge-eng.html
 source_organisation_2: Housing, Infrastructure and Communities Canada
 source_geographical_coverage_2: Canada
+
 auto_progress_calculation: true
 progress_calculation_options:
-- direction: negative
+- series: Number of shelter users experiencing chronic homelessness
+  unit: Number
+  direction: negative
   target: 13433
   base_year: 2016
   target_year: 2028

--- a/meta/14-2-1.md
+++ b/meta/14-2-1.md
@@ -59,10 +59,11 @@ source_organisation_1: Environment and Climate Change Canada
 source_periodicity_1: Annual
 source_geographical_coverage_1: Canada
 
-auto_progress_calculation: false
+auto_progress_calculation: true
 progress_calculation_options:
-- direction: positive
-  target_value: 55.0
+- unit: Percentage
+  direction: positive
+  target: 55.0
   target_year: 2026
 progress_status: not_available
 ---

--- a/meta/15-3-1.md
+++ b/meta/15-3-1.md
@@ -66,9 +66,10 @@ source_organisation_1: Environment and Climate Change Canada
 source_periodicity_1:
 source_geographical_coverage_1: Canada
 
-auto_progress_calculation: false
+auto_progress_calculation: true
 progress_calculation_options:
-- direction: positive
+- series: By species group
+  direction: positive
 progress_status: not_available
 ---
 This indicator corresponds to the Canadian Environmental Sustainability Indicators <a href="https://www.canada.ca/en/environment-climate-change/services/environmental-indicators/canadian-species-index.html"> <em>Canadian species index</em></a>.

--- a/meta/16-5-1.md
+++ b/meta/16-5-1.md
@@ -80,6 +80,10 @@ source_url_2: https://doi.org/10.25318/3510004001-eng
 source_organisation_2: Statistics Canada
 source_periodicity_2: Annual
 source_geographical_coverage_2: Canada, provinces and territories
+
 auto_progress_calculation: true
+progress_calculation_options:
+- series: Adult criminal courts
+  direction: negative
 progress_status: deterioration
 ---


### PR DESCRIPTION
- Added the ability to calculate progress for indicators that have "Series" and "Units" columns in the data files. The series and unit on which the progress measure should operate must be included in the progress_calculation_options within the metadata file as shown here:

```
auto_progress_calculation: true
progress_calculation_options:
- series: Number of shelter users experiencing chronic homelessness
  unit: Number
```
 The series and unit spelling must exactly match the spelling in the indicator's *.csv file. Translation keys do not work.

- Simplified functions to eliminate redundant progress measure calculations for the same indicator. 
- Slightly modified output to indicator_calculation_componenets.yml so that only the progress_status is output for indicators with auto_progress_calculation turned off or for which the progress calculation fails (e.g. if the indicator only has one data point).