### PR TITLE
automatic site rebuild upon push to dev

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -50,7 +50,7 @@ jobs:
         CLEAN: true
     - name: Rebuild site
       run: |
-        curl -X POST https://api.github.com/repos/STAGING_ORGANISATION/STAGING_SITE_REPOSITORY/dispatches \
+        curl -X POST https://api.github.com/repos/sdg-data-canada-odd-donnees/cif-cic_dev/dispatches \
         -H "Accept: application/vnd.github.everest-preview+json" \
         -H "Authorization: token ${{secrets.token}}" \
         --data '{"event_type": "rebuild-staging"}'


### PR DESCRIPTION
Should no longer need to edit cif-cic_dev README file to force a site rebuild. Site rebuild should now happen automatically whenever a commit is pushed to the develop branch of this repository.