### PR TITLE
CIF Review - 3.12.1 Indicator updates review

### DIFF
--- a/meta/3-12-1.md
+++ b/meta/3-12-1.md
@@ -4,10 +4,10 @@ national_indicator_available: Tuberculosis incidence per 100,000 population in I
 target_name: Eliminate tuberculosis across Inuit Nunangat by 2030, and reducing the
   incidence of active tuberculosis by at least 50% by 2025
 
-national_indicator_description: This indicator measures the Tuberculosis incidence
-  rate per 100,000 population in Inuit Nunangat.
+national_indicator_description: This indicator measures the tuberculosis incidence
+  rate per 100,000 population among Inuit in Canada.
 
-national_geographical_coverage: Inuit Nunangat
+national_geographical_coverage: Canada
 
 data_keywords: Indigenous
 
@@ -25,7 +25,7 @@ comments_limitations: Please note that due to existing data limitations, the ind
 ##     value: 0
 ##     preset: target_line
 
-graph_title: Tuberculosis incidence per 100,000 population in Inuit Nunangat
+graph_title: Tuberculosis incidence rate among Inuit across Canada
 graph_type: line
 computation_units: Number per 100,000 population
 indicator_name: Tuberculosis incidence per 100,000 population in Inuit Nunangat
@@ -43,7 +43,7 @@ source_url_text_1: Tuberculosis in Canada - 2010-2020 Summary Report
 source_url_1: https://open.canada.ca/data/en/dataset/17ee0902-055e-415e-b7aa-d9bee1734d35
 source_organisation_1: Public Health Agency of Canada
 source_periodicity_1: Annual
-source_geographical_coverage_1: Inuit Nunangat
+source_geographical_coverage_1: Canada
 
 auto_progress_calculation: true
 progress_calculation_options:

--- a/meta/fr/3-12-1.md
+++ b/meta/fr/3-12-1.md
@@ -2,9 +2,9 @@
 national_indicator_available: "Incidence de la tuberculose par 100 000 habitants dans l’Inuit Nunangat"
 target_name: "Éliminer la tuberculose à l’échelle de l’Inuit Nunangat d’ici 2030, et réduire l’incidence de la tuberculose active d’au moins 50 % d’ici 2025"
 
-national_indicator_description: "Cet indicateur mesure le taux d'incidence de la tuberculose par 100 000 habitants dans l’Inuit Nunangat."
+national_indicator_description: "Cet indicateur mesure le taux d'incidence de la tuberculose par 100 000 habitants chez les Inuits au Canada."
 
-national_geographical_coverage: 'Inuit Nunangat' 
+national_geographical_coverage: Canada
 
 computation_calculations: "Le Système canadien de déclaration des cas de tuberculose est un système de surveillance contenant des données non nominales sur les cas 
 de tuberculose active au Canada. Les données sont recueillies annuellement par les provinces et territoires, analysées par l’Agence de la santé publique du Canada (ASPC) 
@@ -17,7 +17,7 @@ comments_limitations: "Veuillez noter qu'en raison des limites des données exis
 ##     value: 0
 ##     preset: target_line
 
-graph_title: "Incidence de la tuberculose par 100 000 habitants dans l’Inuit Nunangat"
+graph_title: "Taux d'incidence de la tuberculose chez les Inuits au Canada"
 graph_type: line
 computation_units: "Taux d’incidence par 100 000 habitants"
 indicator_name: "Incidence de la tuberculose par 100 000 habitants dans l’Inuit Nunangat"
@@ -34,5 +34,5 @@ source_url_text_1: 'La tuberculose au Canada - Rapport sommaire 2010-2020'
 source_url_1: "https://open.canada.ca/data/fr/dataset/17ee0902-055e-415e-b7aa-d9bee1734d35"
 source_organisation_1: "Agence de la santé publique du Canada"
 source_periodicity_1: Annuelle
-source_geographical_coverage_1: 'Inuit Nunangat'
+source_geographical_coverage_1: Canada
 ---


### PR DESCRIPTION
- #243 
  - edit metadata to refer to "Inuit across Canada" instead of "Inuit Nunangat" due to current data constraints