### PR TITLE
CIF Review - 9.6.1 something odd

### DIFF
--- a/R/indicator_9-6-1.R
+++ b/R/indicator_9-6-1.R
@@ -6,10 +6,11 @@ library(stringr)
 library(tidyr)
 library(httr)
 library(jsonlite)
-library(dotenv)
+# library(dotenv) # un-comment to run on local system with .env file (1/2)
 library(readr)
 
 # Retrieve the API key for electric charging stations from environment variables
+# load_dot_env(".env") # un-comment to run on local system with .env file (2/2)
 ELECTRIC_CHARGING_STATIONS <- Sys.getenv("ELECTRIC_CHARGING_STATIONS")
 
 # Define the URL for the API endpoint
@@ -36,7 +37,19 @@ response <- GET(URL, query = query_params)
 if (status_code(response) == 200) {
   # If the response is successful, read the content and convert it to a data frame
   content <- content(response, "text")
-  data <- read_csv(content)
+  data <- read_csv(content, col_types = cols(.default = "?",
+                                             `BD Blends` = "c",
+                                             `BD Blends (French)` = "c",
+                                             `Hydrogen Pressures` = "c",
+                                             `Hydrogen Standards` = "c",
+                                             `Federal Agency ID` = "c",
+                                             `Federal Agency Name` = "c",
+                                             `Federal Agency Code` = "c",
+                                             `E85 Other Ethanol Blends` = "c",
+                                             `NG PSI` = "c",
+                                             `CNG PSI` = "c"
+                                             )
+                   )
   print(head(data))
 } else {
   # If the response is not successful, print the content and stop the execution with an error message

--- a/data/indicator_9-6-1.csv
+++ b/data/indicator_9-6-1.csv
@@ -7,13 +7,13 @@
 2015,"","",,778
 2016,"","",,1001
 2017,"","",,1597
-2018,"","",,2077
-2019,"","",,4232
-2020,"","",,5107
-2021,"","",,6456
-2022,"","",,8881
-2023,"","",,12483
-2024,"","",,14155
+2018,"","",,2076
+2019,"","",,4230
+2020,"","",,5105
+2021,"","",,6455
+2022,"","",,8877
+2023,"","",,12478
+2024,"","",,14164
 2010,"Alberta","Total electric charging and alternative fuelling stations",48,30
 2010,"Alberta","Propane",48,30
 2011,"Alberta","Total electric charging and alternative fuelling stations",48,32
@@ -57,8 +57,8 @@
 2023,"Alberta","Total electric charging and alternative fuelling stations",48,778
 2023,"Alberta","Electric",48,613
 2023,"Alberta","Propane",48,153
-2024,"Alberta","Total electric charging and alternative fuelling stations",48,912
-2024,"Alberta","Electric",48,747
+2024,"Alberta","Total electric charging and alternative fuelling stations",48,913
+2024,"Alberta","Electric",48,748
 2010,"British Columbia","Total electric charging and alternative fuelling stations",59,39
 2010,"British Columbia","Biodiesel",59,1
 2010,"British Columbia","Propane",59,38
@@ -110,8 +110,8 @@
 2023,"British Columbia","Electric",59,2114
 2023,"British Columbia","Ethanol",59,1
 2023,"British Columbia","Hydrogen",59,9
-2024,"British Columbia","Total electric charging and alternative fuelling stations",59,2548
-2024,"British Columbia","Electric",59,2398
+2024,"British Columbia","Total electric charging and alternative fuelling stations",59,2547
+2024,"British Columbia","Electric",59,2397
 2024,"British Columbia","Hydrogen",59,10
 2024,"British Columbia","Propane",59,131
 2010,"Canada","Biodiesel",,1
@@ -137,33 +137,33 @@
 2017,"Canada","Electric",,1171
 2017,"Canada","Propane",,411
 2018,"Canada","Compressed natural gas",,27
-2018,"Canada","Electric",,1418
+2018,"Canada","Electric",,1417
 2018,"Canada","Hydrogen",,3
 2018,"Canada","Propane",,628
 2019,"Canada","Compressed natural gas",,30
-2019,"Canada","Electric",,3550
+2019,"Canada","Electric",,3548
 2019,"Canada","Hydrogen",,4
 2019,"Canada","Liquefied natural gas",,1
 2019,"Canada","Propane",,646
 2020,"Canada","Compressed natural gas",,31
-2020,"Canada","Electric",,4410
+2020,"Canada","Electric",,4408
 2020,"Canada","Hydrogen",,5
 2020,"Canada","Propane",,659
 2021,"Canada","Compressed natural gas",,33
-2021,"Canada","Electric",,5748
+2021,"Canada","Electric",,5747
 2021,"Canada","Hydrogen",,6
 2021,"Canada","Propane",,667
 2022,"Canada","Compressed natural gas",,41
-2022,"Canada","Electric",,8140
+2022,"Canada","Electric",,8136
 2022,"Canada","Hydrogen",,8
 2022,"Canada","Propane",,690
 2023,"Canada","Compressed natural gas",,45
-2023,"Canada","Electric",,11720
+2023,"Canada","Electric",,11715
 2023,"Canada","Ethanol",,1
 2023,"Canada","Hydrogen",,16
 2023,"Canada","Propane",,699
 2024,"Canada","Compressed natural gas",,46
-2024,"Canada","Electric",,13384
+2024,"Canada","Electric",,13393
 2024,"Canada","Hydrogen",,17
 2024,"Canada","Propane",,705
 2010,"Manitoba","Total electric charging and alternative fuelling stations",46,3
@@ -193,8 +193,8 @@
 2022,"Manitoba","Electric",46,113
 2023,"Manitoba","Total electric charging and alternative fuelling stations",46,264
 2023,"Manitoba","Electric",46,213
-2024,"Manitoba","Total electric charging and alternative fuelling stations",46,343
-2024,"Manitoba","Electric",46,291
+2024,"Manitoba","Total electric charging and alternative fuelling stations",46,344
+2024,"Manitoba","Electric",46,292
 2024,"Manitoba","Propane",46,51
 2011,"New Brunswick","Total electric charging and alternative fuelling stations",13,3
 2011,"New Brunswick","Electric",13,2
@@ -286,8 +286,8 @@
 2022,"Nova Scotia","Total electric charging and alternative fuelling stations",12,159
 2022,"Nova Scotia","Electric",12,155
 2022,"Nova Scotia","Propane",12,4
-2023,"Nova Scotia","Total electric charging and alternative fuelling stations",12,228
-2023,"Nova Scotia","Electric",12,224
+2023,"Nova Scotia","Total electric charging and alternative fuelling stations",12,227
+2023,"Nova Scotia","Electric",12,223
 2024,"Nova Scotia","Total electric charging and alternative fuelling stations",12,249
 2024,"Nova Scotia","Electric",12,245
 2010,"Ontario","Total electric charging and alternative fuelling stations",35,30
@@ -316,31 +316,31 @@
 2017,"Ontario","Compressed natural gas",35,4
 2017,"Ontario","Electric",35,400
 2017,"Ontario","Propane",35,72
-2018,"Ontario","Total electric charging and alternative fuelling stations",35,603
+2018,"Ontario","Total electric charging and alternative fuelling stations",35,602
 2018,"Ontario","Compressed natural gas",35,7
-2018,"Ontario","Electric",35,519
+2018,"Ontario","Electric",35,518
 2018,"Ontario","Propane",35,76
-2019,"Ontario","Total electric charging and alternative fuelling stations",35,912
+2019,"Ontario","Total electric charging and alternative fuelling stations",35,910
 2019,"Ontario","Compressed natural gas",35,8
-2019,"Ontario","Electric",35,822
+2019,"Ontario","Electric",35,820
 2019,"Ontario","Propane",35,81
-2020,"Ontario","Total electric charging and alternative fuelling stations",35,1152
-2020,"Ontario","Electric",35,1055
+2020,"Ontario","Total electric charging and alternative fuelling stations",35,1150
+2020,"Ontario","Electric",35,1053
 2020,"Ontario","Propane",35,88
-2021,"Ontario","Total electric charging and alternative fuelling stations",35,1623
+2021,"Ontario","Total electric charging and alternative fuelling stations",35,1622
 2021,"Ontario","Compressed natural gas",35,9
-2021,"Ontario","Electric",35,1524
+2021,"Ontario","Electric",35,1523
 2021,"Ontario","Propane",35,89
-2022,"Ontario","Total electric charging and alternative fuelling stations",35,2486
+2022,"Ontario","Total electric charging and alternative fuelling stations",35,2482
 2022,"Ontario","Compressed natural gas",35,12
-2022,"Ontario","Electric",35,2369
+2022,"Ontario","Electric",35,2365
 2022,"Ontario","Propane",35,104
-2023,"Ontario","Total electric charging and alternative fuelling stations",35,3868
-2023,"Ontario","Electric",35,3746
+2023,"Ontario","Total electric charging and alternative fuelling stations",35,3864
+2023,"Ontario","Electric",35,3742
 2023,"Ontario","Hydrogen",35,2
 2023,"Ontario","Propane",35,108
-2024,"Ontario","Total electric charging and alternative fuelling stations",35,4442
-2024,"Ontario","Electric",35,4317
+2024,"Ontario","Total electric charging and alternative fuelling stations",35,4440
+2024,"Ontario","Electric",35,4315
 2024,"Ontario","Propane",35,111
 2012,"Prince Edward Island","Total electric charging and alternative fuelling stations",11,2
 2012,"Prince Edward Island","Electric",11,2
@@ -413,9 +413,9 @@
 2023,"Quebec","Electric",24,4112
 2023,"Quebec","Hydrogen",24,5
 2023,"Quebec","Propane",24,171
-2024,"Quebec","Total electric charging and alternative fuelling stations",24,4797
+2024,"Quebec","Total electric charging and alternative fuelling stations",24,4811
 2024,"Quebec","Compressed natural gas",24,13
-2024,"Quebec","Electric",24,4607
+2024,"Quebec","Electric",24,4621
 2014,"Saskatchewan","Total electric charging and alternative fuelling stations",47,10
 2014,"Saskatchewan","Electric",47,5
 2014,"Saskatchewan","Propane",47,5
@@ -441,8 +441,8 @@
 2022,"Saskatchewan","Electric",47,100
 2023,"Saskatchewan","Total electric charging and alternative fuelling stations",47,217
 2023,"Saskatchewan","Electric",47,142
-2024,"Saskatchewan","Total electric charging and alternative fuelling stations",47,253
-2024,"Saskatchewan","Electric",47,178
+2024,"Saskatchewan","Total electric charging and alternative fuelling stations",47,251
+2024,"Saskatchewan","Electric",47,176
 2019,"Yukon","Total electric charging and alternative fuelling stations",60,4
 2019,"Yukon","Electric",60,2
 2019,"Yukon","Propane",60,2
@@ -454,5 +454,3 @@
 2023,"Yukon","Electric",60,37
 2024,"Yukon","Total electric charging and alternative fuelling stations",60,40
 2024,"Yukon","Electric",60,38
-2024,,"Total electric charging and alternative fuelling stations",,2
-2024,,"Electric",,2


### PR DESCRIPTION
- #519
  - Odd data appears to be in the final 2 lines of the csv:
  ```
  2024,,"Total electric charging and alternative fuelling stations",,2
  2024,,"Electric",,2
  ```
  These rows have empty/NA Geography values which do not match any other Geography values in the column so they are accounted for separately. Headline data for this indicator use `""` for the Geography value. I am not sure where the empty/NA Geography value is coming from at this time because no odd data is output when I run the script locally.
  - Data update run on my local system to fix odd values 
  - Will try to update via the workflow after this update to see if the odd data is reproduced again.