### PR TITLE
python 3.10 update

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/update-progress-measures.yml
+++ b/.github/workflows/update-progress-measures.yml
@@ -10,17 +10,17 @@ on:
 
 jobs:
   run-progress-measure:
-    runs-on: windows-2019
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         
-    - name: Set up Python 3.7
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.10
         
     - name: Install dependencies
       run: |

--- a/.github/workflows/update-progress-measures.yml
+++ b/.github/workflows/update-progress-measures.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: '3.10'
         
     - name: Install dependencies
       run: |

--- a/R/indicator_9-6-1.R
+++ b/R/indicator_9-6-1.R
@@ -160,7 +160,7 @@ data_final <-
   mutate(Value = cumsum(Value)) %>%
   ungroup() %>%
   filter(
-    Year >= 2010 # Filter for data from the year 2010 onward
+    Year >= 2010 & Year <= format(Sys.Date(), "%Y") # Filter for data from the year 2010 onward until the current year
   ) %>%
   arrange(Geography, Year) 
 

--- a/data/indicator_9-6-1.csv
+++ b/data/indicator_9-6-1.csv
@@ -10,11 +10,10 @@
 2018,"","",,2000
 2019,"","",,4129
 2020,"","",,4996
-2021,"","",,6320
-2022,"","",,8714
-2023,"","",,12215
-2024,"","",,14616
-2025,"","",,14617
+2021,"","",,6321
+2022,"","",,8715
+2023,"","",,12216
+2024,"","",,14628
 2010,"Alberta","Total electric charging and alternative fuelling stations",48,26
 2010,"Alberta","Propane",48,26
 2011,"Alberta","Total electric charging and alternative fuelling stations",48,27
@@ -58,8 +57,8 @@
 2023,"Alberta","Compressed natural gas",48,13
 2023,"Alberta","Electric",48,598
 2023,"Alberta","Propane",48,142
-2024,"Alberta","Total electric charging and alternative fuelling stations",48,926
-2024,"Alberta","Electric",48,771
+2024,"Alberta","Total electric charging and alternative fuelling stations",48,925
+2024,"Alberta","Electric",48,770
 2010,"British Columbia","Total electric charging and alternative fuelling stations",59,39
 2010,"British Columbia","Biodiesel",59,1
 2010,"British Columbia","Propane",59,38
@@ -97,22 +96,22 @@
 2020,"British Columbia","Electric",59,650
 2020,"British Columbia","Hydrogen",59,3
 2020,"British Columbia","Propane",59,124
-2021,"British Columbia","Total electric charging and alternative fuelling stations",59,1069
+2021,"British Columbia","Total electric charging and alternative fuelling stations",59,1070
 2021,"British Columbia","Compressed natural gas",59,5
-2021,"British Columbia","Electric",59,934
+2021,"British Columbia","Electric",59,935
 2021,"British Columbia","Hydrogen",59,4
 2021,"British Columbia","Propane",59,125
-2022,"British Columbia","Total electric charging and alternative fuelling stations",59,1568
-2022,"British Columbia","Electric",59,1428
+2022,"British Columbia","Total electric charging and alternative fuelling stations",59,1569
+2022,"British Columbia","Electric",59,1429
 2022,"British Columbia","Hydrogen",59,5
 2022,"British Columbia","Propane",59,129
-2023,"British Columbia","Total electric charging and alternative fuelling stations",59,2181
+2023,"British Columbia","Total electric charging and alternative fuelling stations",59,2182
 2023,"British Columbia","Compressed natural gas",59,7
-2023,"British Columbia","Electric",59,2034
+2023,"British Columbia","Electric",59,2035
 2023,"British Columbia","Ethanol",59,1
 2023,"British Columbia","Hydrogen",59,9
-2024,"British Columbia","Total electric charging and alternative fuelling stations",59,2632
-2024,"British Columbia","Electric",59,2482
+2024,"British Columbia","Total electric charging and alternative fuelling stations",59,2638
+2024,"British Columbia","Electric",59,2488
 2024,"British Columbia","Hydrogen",59,10
 2024,"British Columbia","Propane",59,131
 2010,"Canada","Biodiesel",,1
@@ -151,23 +150,22 @@
 2020,"Canada","Hydrogen",,5
 2020,"Canada","Propane",,632
 2021,"Canada","Compressed natural gas",,33
-2021,"Canada","Electric",,5638
+2021,"Canada","Electric",,5639
 2021,"Canada","Hydrogen",,6
 2021,"Canada","Propane",,640
 2022,"Canada","Compressed natural gas",,41
-2022,"Canada","Electric",,7999
+2022,"Canada","Electric",,8000
 2022,"Canada","Hydrogen",,8
 2022,"Canada","Propane",,663
 2023,"Canada","Compressed natural gas",,46
-2023,"Canada","Electric",,11478
+2023,"Canada","Electric",,11479
 2023,"Canada","Ethanol",,2
 2023,"Canada","Hydrogen",,16
 2023,"Canada","Propane",,671
 2024,"Canada","Compressed natural gas",,47
-2024,"Canada","Electric",,13866
+2024,"Canada","Electric",,13878
 2024,"Canada","Hydrogen",,17
 2024,"Canada","Propane",,682
-2025,"Canada","Electric",,13867
 2010,"Manitoba","Total electric charging and alternative fuelling stations",46,3
 2010,"Manitoba","Electric",46,1
 2013,"Manitoba","Total electric charging and alternative fuelling stations",46,8
@@ -195,8 +193,8 @@
 2022,"Manitoba","Electric",46,109
 2023,"Manitoba","Total electric charging and alternative fuelling stations",46,250
 2023,"Manitoba","Electric",46,199
-2024,"Manitoba","Total electric charging and alternative fuelling stations",46,347
-2024,"Manitoba","Electric",46,295
+2024,"Manitoba","Total electric charging and alternative fuelling stations",46,346
+2024,"Manitoba","Electric",46,294
 2024,"Manitoba","Propane",46,51
 2011,"New Brunswick","Total electric charging and alternative fuelling stations",13,3
 2011,"New Brunswick","Electric",13,2
@@ -340,8 +338,8 @@
 2023,"Ontario","Electric",35,3684
 2023,"Ontario","Hydrogen",35,2
 2023,"Ontario","Propane",35,109
-2024,"Ontario","Total electric charging and alternative fuelling stations",35,4667
-2024,"Ontario","Electric",35,4537
+2024,"Ontario","Total electric charging and alternative fuelling stations",35,4668
+2024,"Ontario","Electric",35,4538
 2024,"Ontario","Propane",35,115
 2012,"Prince Edward Island","Total electric charging and alternative fuelling stations",11,2
 2012,"Prince Edward Island","Electric",11,2
@@ -414,12 +412,10 @@
 2023,"Quebec","Electric",24,4048
 2023,"Quebec","Hydrogen",24,5
 2023,"Quebec","Propane",24,153
-2024,"Quebec","Total electric charging and alternative fuelling stations",24,4898
+2024,"Quebec","Total electric charging and alternative fuelling stations",24,4905
 2024,"Quebec","Compressed natural gas",24,13
-2024,"Quebec","Electric",24,4725
+2024,"Quebec","Electric",24,4732
 2024,"Quebec","Propane",24,154
-2025,"Quebec","Total electric charging and alternative fuelling stations",24,4899
-2025,"Quebec","Electric",24,4726
 2014,"Saskatchewan","Total electric charging and alternative fuelling stations",47,10
 2014,"Saskatchewan","Electric",47,5
 2014,"Saskatchewan","Propane",47,5

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,3 +2,4 @@ git+https://github.com/dougmet/yamlmd
 git+https://github.com/open-sdg/sdg-build@2.3.1
 frictionless==4.40.8
 pydantic==1.*
+numpy==1.26.4

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,3 +3,4 @@ git+https://github.com/open-sdg/sdg-build@2.3.1
 frictionless==4.40.8
 pydantic==1.*
 numpy==1.26.4
+packaging


### PR DESCRIPTION
Update workflows to python 3.10 because python 3.7 is no longer available on ubuntu-latest.