### PR TITLE
Progress calculation option updates

### DIFF
--- a/.github/workflows/update-progress-measures.yml
+++ b/.github/workflows/update-progress-measures.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - develop
   schedule:
-  # run at 10:00am on tuesday
-      - cron: '00 14 * * 2'
+  # run at 10:30am on tuesday
+      - cron: '30 14 * * 2'
 
 jobs:
   run-progress-measure:

--- a/meta/13-3-1.md
+++ b/meta/13-3-1.md
@@ -86,6 +86,5 @@ source_geographical_coverage_2: Canada, provinces and territories
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
-# manually calculated progress measure
 progress_status: substantial_progress
 ---

--- a/meta/14-2-1.md
+++ b/meta/14-2-1.md
@@ -76,7 +76,7 @@ source_organisation_1: Environment and Climate Change Canada
 source_periodicity_1: Annual
 source_geographical_coverage_1: Canada
 
-auto_progress_calculation: false
+auto_progress_calculation: true
 progress_calculation_options:
 - unit: Percentage
   direction: positive

--- a/meta/6-1-1.md
+++ b/meta/6-1-1.md
@@ -39,7 +39,8 @@ source_url_text_1: Indigenous Services Canada. Custom tabulation
 source_url_1: https://www.sac-isc.gc.ca/eng/1506514143353/1533317130660
 source_organisation_1: Indigenous Services Canada
 source_geographical_coverage_1: Communities on reserves south of the 60th parallel
-auto_progress_calculation: false
+
+auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
   target: 0

--- a/meta/6-3-1.md
+++ b/meta/6-3-1.md
@@ -52,8 +52,10 @@ source_url_2: https://doi.org/10.25318/1710000501-eng
 source_organisation_2: Statistics Canada
 source_periodicity_2: 
 Source_geographical_coverage_2: Canada, provinces and territories
-auto_progress_calculation: false
+
+auto_progress_calculation: true
 progress_calculation_options:
-- direction: negative
+- series: Total water use
+  direction: negative
 progress_status: not_available
 ---

--- a/meta/9-6-1.md
+++ b/meta/9-6-1.md
@@ -51,7 +51,7 @@ graph_type: line
 
 graph_annotations:
 - unit: Number
-  value: 16296
+  value: 19059
   preset: target_line
 
 data_start_values:
@@ -74,8 +74,8 @@ source_geographical_coverage_1: Canada, provinces and territories
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
-  target: 16296
-  base_year: 2023
-  target_year: 2024
+  target: 19059
+  base_year: 2024
+  target_year: 2025
 progress_status: negligible_progress
 ---


### PR DESCRIPTION
- Update 9.6.1 target for 2025.
- Turn on progress calculation for 6.1.1, 6.3.1, 14.2.1
  - Use 'Total water use' series for 6.3.1 progress calculation
- Increase scheduled time between starts of data update and progress measure workflows from 30 minutes to 60 minutes.
