### PR TITLE
"Footnote: Data last updated:" bugfix test

### DIFF
--- a/meta/1-1-1.md
+++ b/meta/1-1-1.md
@@ -27,10 +27,12 @@ comments_limitations: It covers all individuals in Canada, excluding persons liv
 
 graph_title: Percentage of persons in low income
 graph_type: line
-graph_annotations:
-- unit: Percentage
-  value: 7.25
-  preset: target_line
+# graph_annotations:
+# - unit: Percentage
+#   value: 7.25
+#   preset: target_line
+graph_target_lines:
+- value: 7.25
 computation_units: Percentage
 data_start_values:
 - field: Geography

--- a/meta/fr/1-1-1.md
+++ b/meta/fr/1-1-1.md
@@ -12,10 +12,12 @@ comments_limitations: "L'enquête est menée dans l'ensemble du pays, tant dans 
 
 graph_title: Pourcentage de personnes à faible revenu
 graph_type: line
-graph_annotations:
-  - unit: Pourcentage
-    value: 7.25
-    preset: target_line
+# graph_annotations:
+#   - unit: Pourcentage
+#     value: 7.25
+#     preset: target_line
+graph_target_lines:
+  - value: 7.25
 computation_units: Pourcentage
 data_start_values:
   - field: "Géographie"


### PR DESCRIPTION
Issue: "Footnote: Data last updated:" appears under the chart when a target line is added to the chart despite none of these fields being specified in the metadata files.
Solution: Swap `graph_annotations` for `graph_target_lines`

Test bugfix on 1.1.1