### PR TITLE
upgrade to actions/cache v3

### DIFF
--- a/.github/workflows/refresh-indicator-data.yml
+++ b/.github/workflows/refresh-indicator-data.yml
@@ -37,7 +37,7 @@ jobs:
   
     - name: Cache R packages
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ env.R_LIBS_USER }}
         key: ${{ runner.os }}-dataupdate


### PR DESCRIPTION
actions/cache v2 is no longer supported on GitHub Actions