### PR TITLE
Unable to assess / Not available separation

### DIFF
--- a/meta/1-1-1.md
+++ b/meta/1-1-1.md
@@ -69,5 +69,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - target: 7.25
   target_year: 2030
-progress_status: substantial_progress
 ---

--- a/meta/1-2-1.md
+++ b/meta/1-2-1.md
@@ -49,5 +49,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: moderate_progress
 ---

--- a/meta/1-3-1.md
+++ b/meta/1-3-1.md
@@ -39,5 +39,4 @@ source_periodicity_1: Quarterly
 source_geographical_coverage_1: Canada
 
 auto_progress_calculation: true
-progress_status: negligible_progress
 ---

--- a/meta/1-4-1.md
+++ b/meta/1-4-1.md
@@ -62,6 +62,5 @@ source_geographical_coverage_1: Canada (excluding territories), provinces and se
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
-progress_status: moderate_progress
 ---
 

--- a/meta/10-1-1.md
+++ b/meta/10-1-1.md
@@ -57,5 +57,4 @@ source_geographical_coverage_1: Canada (excluding territories) and provinces
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: moderate_progress
 ---

--- a/meta/10-2-1.md
+++ b/meta/10-2-1.md
@@ -61,5 +61,4 @@ source_geographical_coverage_1: Canada, Province or territory, Census Metropolit
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: deterioration
 ---

--- a/meta/11-1-1.md
+++ b/meta/11-1-1.md
@@ -77,5 +77,4 @@ progress_calculation_options:
   target: 13433
   base_year: 2016
   target_year: 2028
-progress_status: deterioration
 ---

--- a/meta/11-2-1.md
+++ b/meta/11-2-1.md
@@ -83,5 +83,4 @@ source_geographical_coverage_2: Canada, Province or territory, Census metropolit
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: deterioration
 ---

--- a/meta/11-3-1.md
+++ b/meta/11-3-1.md
@@ -78,6 +78,5 @@ progress_calculation_options:
   base_year: 2005
   target: 85
   target_year: 2030
-progress_status: target_achieved
 ---
 This indicator corresponds to the Canadian Environmental Sustainability Indicators <a href="https://www.canada.ca/en/environment-climate-change/services/environmental-indicators/population-exposure-outdoor-air-pollutants.html"> <em>Population exposure to outdoor air pollutants</em></a>.

--- a/meta/11-4-1.md
+++ b/meta/11-4-1.md
@@ -74,5 +74,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: deterioration
 ---

--- a/meta/11-5-1.md
+++ b/meta/11-5-1.md
@@ -78,5 +78,4 @@ progress_calculation_options:
 - direction: positive
   target: 22
   target_year: 2030
-progress_status: deterioration
 ---

--- a/meta/11-6-1.md
+++ b/meta/11-6-1.md
@@ -73,6 +73,5 @@ progress_calculation_options:
   base_year: 2014
   target_year: 2030
   target: 490
-progress_status: negligible_progress
 ---
 

--- a/meta/11-7-1.md
+++ b/meta/11-7-1.md
@@ -102,5 +102,4 @@ progress_calculation_options:
 - series: Aged 18 years and older
   direction: positive
   limit: 100
-progress_status: deterioration
 ---

--- a/meta/12-1-1.md
+++ b/meta/12-1-1.md
@@ -50,7 +50,7 @@ graph_type: line
 data_non_statistical: false
 data_show_map: true
 
-progress_status: substantial_progress
+
 
 
 # Source

--- a/meta/12-2-1.md
+++ b/meta/12-2-1.md
@@ -72,5 +72,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: deterioration
 ---

--- a/meta/12-3-1.md
+++ b/meta/12-3-1.md
@@ -81,5 +81,4 @@ source_geographical_coverage_2: Canada, Province or territory
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
-progress_status: deterioration
 ---

--- a/meta/12-4-1.md
+++ b/meta/12-4-1.md
@@ -59,5 +59,4 @@ source_geographical_coverage_1: Canada, provinces and territories
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: negligible_progress
 ---

--- a/meta/13-1-1.md
+++ b/meta/13-1-1.md
@@ -87,11 +87,10 @@ source_periodicity_1: Annual
 source_geographical_coverage_1: Canada, provinces and territories
 
 auto_progress_calculation: false
+progress_status: not_available # manual override from ECCC
 progress_calculation_options:
 - direction: negative
   target_year: 2030
   target: 456.8949698
-# manual override from ECCC
-progress_status: not_available
 ---
 This indicator corresponds to the Canadian Environmental Sustainability Indicators <a href="https://www.canada.ca/en/environment-climate-change/services/environmental-indicators/greenhouse-gas-emissions.html"> <em>Greenhouse gas emissions</em></a>.

--- a/meta/13-1-1.md
+++ b/meta/13-1-1.md
@@ -87,7 +87,7 @@ source_periodicity_1: Annual
 source_geographical_coverage_1: Canada, provinces and territories
 
 auto_progress_calculation: false
-progress_status: not_available # manual override from ECCC
+progress_status: not_available_manual # manual override from ECCC
 progress_calculation_options:
 - direction: negative
   target_year: 2030

--- a/meta/13-2-1.md
+++ b/meta/13-2-1.md
@@ -54,5 +54,4 @@ source_geographical_coverage_1: Canada
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: deterioration
 ---

--- a/meta/13-3-1.md
+++ b/meta/13-3-1.md
@@ -184,5 +184,4 @@ progress_calculation_options:
     value: Active transportation assets
   - field: Type of municipality by population size
     value: All municipalities
-progress_status: not_available
 ---

--- a/meta/13-4-1.md
+++ b/meta/13-4-1.md
@@ -42,5 +42,4 @@ source_geographical_coverage_1: Canada, provinces and territories
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
-progress_status: substantial_progress
 ---

--- a/meta/14-1-1.md
+++ b/meta/14-1-1.md
@@ -69,6 +69,5 @@ progress_calculation_options:
 - direction: positive
   target: 30
   target_year: 2030
-progress_status: substantial_progress
 ---
 This indicator corresponds to the Canadian Environmental Sustainability Indicators <a href="https://www.canada.ca/en/environment-climate-change/services/environmental-indicators/conserved-areas.html"> <em>Canada's conserved areas</em></a>.

--- a/meta/14-2-1.md
+++ b/meta/14-2-1.md
@@ -83,7 +83,6 @@ progress_calculation_options:
   direction: positive
   target: 55.0
   target_year: 2026
-progress_status: deterioration
 ---
 This indicator corresponds to the Canadian Environmental Sustainability Indicators <a href="https://www.canada.ca/en/environment-climate-change/services/environmental-indicators/status-key-fish-stocks.html"> <em>Status of key fish stocks</em></a>.
 

--- a/meta/15-1-1.md
+++ b/meta/15-1-1.md
@@ -69,6 +69,5 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: negligible_progress
 ---
 This indicator corresponds to the Canadian Environmental Sustainability Indicators <a href="https://www.canada.ca/en/environment-climate-change/services/environmental-indicators/general-status-wild-species.html"> <em>General status of wild species</em></a>.

--- a/meta/15-2-1.md
+++ b/meta/15-2-1.md
@@ -86,6 +86,5 @@ progress_calculation_options:
   base_year: 2019
   target_year: 2026
   target: 60
-progress_status: deterioration
 ---
 This indicator corresponds to the Canadian Environmental Sustainability Indicators <a href="https://www.canada.ca/en/environment-climate-change/services/environmental-indicators/species-risk-population-trends.html"> <em>Species at risk population trends</em></a>.

--- a/meta/15-3-1.md
+++ b/meta/15-3-1.md
@@ -70,6 +70,5 @@ auto_progress_calculation: true
 progress_calculation_options:
 - series: By species group
   direction: positive
-progress_status: not_available
 ---
 This indicator corresponds to the Canadian Environmental Sustainability Indicators <a href="https://www.canada.ca/en/environment-climate-change/services/environmental-indicators/canadian-species-index.html"> <em>Canadian species index</em></a>.

--- a/meta/15-4-1.md
+++ b/meta/15-4-1.md
@@ -73,6 +73,5 @@ progress_calculation_options:
 - direction: positive
   target: 30
   target_year: 2030
-progress_status: negligible_progress
 ---
 This indicator corresponds to the Canadian Environmental Sustainability Indicators <a href="https://www.canada.ca/en/environment-climate-change/services/environmental-indicators/conserved-areas.html"> <em>Canada's conserved areas</em></a>.

--- a/meta/15-5-1.md
+++ b/meta/15-5-1.md
@@ -55,6 +55,5 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
   target: 100
-progress_status: target_achieved
 ---
 This indicator corresponds to the Canadian Environmental Sustainability Indicators <a href="https://www.canada.ca/en/environment-climate-change/services/environmental-indicators/forest-management-disturbances.html"> <em>Forest management and disturbances</em></a>.

--- a/meta/15-6-1.md
+++ b/meta/15-6-1.md
@@ -62,6 +62,7 @@ source_url_text_3: Global Forest Resources Assessment 2020 Canada - Report (PDF)
 source_url_3: http://www.fao.org/3/ca9983en/ca9983en.pdf
 source_organisation_3: Food and Agriculture Organization of the United Nations
 source_geographical_coverage_3: Canada
+
 auto_progress_calculation: false
 progress_status: not_available
 ---

--- a/meta/16-1-1.md
+++ b/meta/16-1-1.md
@@ -68,5 +68,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: negligible_progress
 ---

--- a/meta/16-2-1.md
+++ b/meta/16-2-1.md
@@ -63,5 +63,4 @@ source_geographical_coverage_1: Canada, provinces and territories
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: deterioration
 ---

--- a/meta/16-3-1.md
+++ b/meta/16-3-1.md
@@ -66,5 +66,4 @@ source_geographical_coverage_1: Canada, provinces and territories, census metrop
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: deterioration
 ---

--- a/meta/16-4-1.md
+++ b/meta/16-4-1.md
@@ -77,7 +77,6 @@ progress_calculation_options:
   - field: Type of case
     value: Total cases
   # progress column values for <= 3 months are actually <= 3 months + 3-6 months
-  - field: Number of months
+  - field: Elapsed time
     value: Less than or equal to 3 months
-progress_status: not_available
 ---

--- a/meta/16-5-1.md
+++ b/meta/16-5-1.md
@@ -85,5 +85,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - series: Adult criminal courts
   direction: negative
-progress_status: deterioration
 ---

--- a/meta/16-6-1.md
+++ b/meta/16-6-1.md
@@ -60,5 +60,4 @@ source_geographical_coverage_1: Canada, provinces and territories
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: substantial_progress
 ---

--- a/meta/16-7-1.md
+++ b/meta/16-7-1.md
@@ -68,6 +68,5 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: not_available
 ---
 <i>This indicator does not display a progress status as there is only one data point currently available.</i>

--- a/meta/17-1-1.md
+++ b/meta/17-1-1.md
@@ -76,5 +76,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: moderate_progress
 ---

--- a/meta/17-2-1.md
+++ b/meta/17-2-1.md
@@ -55,5 +55,4 @@ source_active_2: false
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
-progress_status: substantial_progress
 ---

--- a/meta/17-3-1.md
+++ b/meta/17-3-1.md
@@ -74,5 +74,4 @@ source_geographical_coverage_2: Countries and world regions
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
-progress_status: substantial_progress
 ---

--- a/meta/2-1-1.md
+++ b/meta/2-1-1.md
@@ -80,5 +80,4 @@ source_geographical_coverage_5: Territories
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: deterioration
 ---

--- a/meta/2-2-1.md
+++ b/meta/2-2-1.md
@@ -48,5 +48,4 @@ progress_calculation_options:
 - direction: positive
   target: 71
   target_year: 2030
-progress_status: deterioration
 ---

--- a/meta/3-1-1.md
+++ b/meta/3-1-1.md
@@ -71,5 +71,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: deterioration
 ---

--- a/meta/3-10-1.md
+++ b/meta/3-10-1.md
@@ -94,5 +94,4 @@ progress_calculation_options:
 - disaggregation:
   - field: Disease
     value: Tuberculosis
-progress_status: not_available
 ---

--- a/meta/3-11-1.md
+++ b/meta/3-11-1.md
@@ -123,5 +123,4 @@ progress_calculation_options:
     value: Both sexes
   - field: Leading causes of death
     value: Intentional self-harm (suicide)
-progress_status: not_available
 ---

--- a/meta/3-12-1.md
+++ b/meta/3-12-1.md
@@ -50,5 +50,4 @@ progress_calculation_options:
 - direction: negative
   target: 0
   target_year: 2030
-progress_status: deterioration
 ---

--- a/meta/3-13-1.md
+++ b/meta/3-13-1.md
@@ -55,5 +55,4 @@ progress_calculation_options:
 - direction: negative
   target: 10
   target_year: 2028
-progress_status: deterioration
 ---

--- a/meta/3-14-1.md
+++ b/meta/3-14-1.md
@@ -59,5 +59,4 @@ progress_calculation_options:
 - direction: negative
   target: 5
   target_year: 2035
-progress_status: moderate_progress
 ---

--- a/meta/3-15-1.md
+++ b/meta/3-15-1.md
@@ -46,5 +46,4 @@ source_geographical_coverage_1: Canada (excluding territories) and provinces
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: deterioration
 ---

--- a/meta/3-2-1.md
+++ b/meta/3-2-1.md
@@ -38,6 +38,5 @@ auto_progress_calculation: true
 progress_calculation_options:
 - target: 10
   target_year: 2025
-progress_status: not_available
 ---
 <i>This indicator does not display a progress status as there is only one data point currently available.</i>

--- a/meta/3-3-1.md
+++ b/meta/3-3-1.md
@@ -49,5 +49,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
   base_year: 2011
-progress_status: not_available
 ---

--- a/meta/3-4-1.md
+++ b/meta/3-4-1.md
@@ -56,5 +56,4 @@ progress_calculation_options:
   base_year: 2015
   target_year: 2025
   target: 8
-progress_status: target_achieved
 ---

--- a/meta/3-5-1.md
+++ b/meta/3-5-1.md
@@ -56,7 +56,4 @@ progress_calculation_options:
     value: Ages 18 to 79
   direction: positive
   limit: 100
-
-progress_status: not_available
 ---
-<i>This indicator is composed of multiple sub-indicators, therefore it doesn't report an aggregate progress status. Progress for sub-indicators available upon request.</i>

--- a/meta/3-6-1.md
+++ b/meta/3-6-1.md
@@ -16,7 +16,7 @@ computation_calculations:
   0 to 10 for how respondents feel about their life as a whole at the moment. Satisfied
   or very satisfied represents those who indicated a value of 6 or more out of 10.
 
-comments_limitations: |
+comments_limitations: |-
   Data disaggregated by immigration status and visible minority are only available from 2022 onward.
   <br><br>
   The indicator covers the population 18 years of age and over living in the ten provinces and the three territories. Excluded from the survey's coverage are: persons living on reserves and other Aboriginal settlements in the provinces; full-time members of the Canadian Forces; the institutionalized population, and persons living in the Quebec health regions of Région du Nunavik and Région des Terres-Cries-de-la-Baie-James. Altogether, these exclusions represent less than 3% of the Canadian population aged 18 and over.
@@ -74,5 +74,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: deterioration
 ---

--- a/meta/3-7-1.md
+++ b/meta/3-7-1.md
@@ -71,5 +71,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: deterioration
 ---

--- a/meta/3-8-1.md
+++ b/meta/3-8-1.md
@@ -83,5 +83,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: deterioration
 ---

--- a/meta/3-9-1.md
+++ b/meta/3-9-1.md
@@ -59,10 +59,10 @@ source_periodicity_1: Occasional
 source_geographical_coverage_1: Canada, provinces and territories
 
 auto_progress_calculation: false # confirmation from SME needed
+progress_status: not_available
 progress_calculation_options:
 - direction: positive
   target: 90
   target_year: 2025
-progress_status: not_available
 ---
 <i>This indicator is composed of multiple sub-indicators, therefore it doesn't report an aggregate progress status. Progress for sub-indicators available upon request.</i>

--- a/meta/4-1-1.md
+++ b/meta/4-1-1.md
@@ -53,5 +53,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: moderate_progress
 ---

--- a/meta/4-2-1.md
+++ b/meta/4-2-1.md
@@ -67,5 +67,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: substantial_progress
 ---

--- a/meta/4-3-1.md
+++ b/meta/4-3-1.md
@@ -44,5 +44,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: deterioration
 ---

--- a/meta/5-1-1.md
+++ b/meta/5-1-1.md
@@ -50,6 +50,5 @@ progress_calculation_options:
     value: Intimate partner
   - field: Sex
     value: Women
-progress_status: not_available
 ---
 <i>This indicator does not display a progress status as there is only one data point currently available.</i>

--- a/meta/5-2-1.md
+++ b/meta/5-2-1.md
@@ -56,6 +56,5 @@ progress_calculation_options:
   base_year: 2018
   target_year: 2026
   target: 11.495
-progress_status: not_available
 ---
 <i>This indicator does not display a progress status as there is only one data point currently available.</i>

--- a/meta/5-3-1.md
+++ b/meta/5-3-1.md
@@ -104,5 +104,4 @@ progress_calculation_options:
   disaggregation:
   - field: Leadership position
     value: First Nations council members
-progress_status: not_available
 ---

--- a/meta/5-4-1.md
+++ b/meta/5-4-1.md
@@ -69,5 +69,4 @@ progress_calculation_options:
   # Ratio of time spent by women+ / men+ is calculated in the 'Total, all persons' row of the progress column
   - field: Gender
     value: Total, all persons
-progress_status: not_available
 ---

--- a/meta/5-5-1.md
+++ b/meta/5-5-1.md
@@ -70,5 +70,4 @@ source_geographical_coverage_1: Canada and provinces
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
-progress_status: moderate_progress
 ---

--- a/meta/6-1-1.md
+++ b/meta/6-1-1.md
@@ -45,5 +45,4 @@ progress_calculation_options:
 - direction: negative
   target: 0
   target_year: 2030
-progress_status: negligible_progress
 ---

--- a/meta/6-2-1.md
+++ b/meta/6-2-1.md
@@ -60,5 +60,4 @@ source_geographical_coverage_3: Canada, Province or territory
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: deterioration
 ---

--- a/meta/6-3-1.md
+++ b/meta/6-3-1.md
@@ -61,5 +61,4 @@ progress_calculation_options:
 - direction: negative
   series: Total water use
   unit: Cubic metres
-progress_status: not_available
 ---

--- a/meta/6-4-1.md
+++ b/meta/6-4-1.md
@@ -80,7 +80,7 @@ data_show_map: false
 source_active_1: true
 source_url_text_1: 'Canadian Environmental Sustainability Indicators Program, Water quality in Canadian rivers'
 source_url_1: https://www.canada.ca/en/environment-climate-change/services/environmental-indicators/water-quality-canadian-rivers.html
-source_organisation_1: ' Environment and Climate Change Canada '
+source_organisation_1: Environment and Climate Change Canada
 source_periodicity_1:
 source_geographical_coverage_1: Canada and regions
 source_release_date_1:

--- a/meta/6-4-1.md
+++ b/meta/6-4-1.md
@@ -85,9 +85,9 @@ source_periodicity_1:
 source_geographical_coverage_1: Canada and regions
 source_release_date_1:
 
-auto_progress_calculation: false
+auto_progress_calculation: false # SME recommendation
+progress_status: not_available
 progress_calculation_options:
 - direction: positive
-progress_status: not_available
 ---
 This indicator corresponds to the Canadian Environmental Sustainability Indicators <a href="https://www.canada.ca/en/environment-climate-change/services/environmental-indicators/water-quality-canadian-rivers.html"> <em>Water quality in Canadian rivers</em></a>.

--- a/meta/6-4-1.md
+++ b/meta/6-4-1.md
@@ -86,7 +86,7 @@ source_geographical_coverage_1: Canada and regions
 source_release_date_1:
 
 auto_progress_calculation: false # SME recommendation
-progress_status: not_available
+progress_status: not_available_manual
 progress_calculation_options:
 - direction: positive
 ---

--- a/meta/6-5-1.md
+++ b/meta/6-5-1.md
@@ -64,5 +64,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   target: 85
-progress_status: deterioration
 ---

--- a/meta/6-6-1.md
+++ b/meta/6-6-1.md
@@ -57,5 +57,4 @@ progress_calculation_options:
 - direction: positive
   target: 100
   target_year: 2040
-progress_status: deterioration
 ---

--- a/meta/7-1-1.md
+++ b/meta/7-1-1.md
@@ -63,5 +63,4 @@ progress_calculation_options:
 - direction: positive
   target: 600
   target_year: 2030
-progress_status: substantial_progress
 ---

--- a/meta/7-2-1.md
+++ b/meta/7-2-1.md
@@ -87,5 +87,4 @@ progress_calculation_options:
 - direction: positive
   target: 90
   target_year: 2030
-progress_status: deterioration
 ---

--- a/meta/7-3-1.md
+++ b/meta/7-3-1.md
@@ -60,5 +60,4 @@ source_geographical_coverage_2: Canada, provinces and territories
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: moderate_progress
 ---

--- a/meta/8-1-1.md
+++ b/meta/8-1-1.md
@@ -85,5 +85,4 @@ source_geographical_coverage_4: Canada, Geographical region of Canada, Province 
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: moderate_progress
 ---

--- a/meta/8-2-1.md
+++ b/meta/8-2-1.md
@@ -128,5 +128,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: negligible_progress
 ---

--- a/meta/8-3-1.md
+++ b/meta/8-3-1.md
@@ -43,5 +43,4 @@ source_geographical_coverage_1: Canada, provinces and territories
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: moderate_progress
 ---

--- a/meta/8-4-1.md
+++ b/meta/8-4-1.md
@@ -65,5 +65,4 @@ source_geographical_coverage_1: Canada (excluding territories) and provinces
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: substantial_progress
 ---

--- a/meta/8-5-1.md
+++ b/meta/8-5-1.md
@@ -55,5 +55,4 @@ source_geographical_coverage_2: Canada, provinces and territories
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
-progress_status: negligible_progress
 ---

--- a/meta/8-6-1.md
+++ b/meta/8-6-1.md
@@ -68,5 +68,4 @@ progress_calculation_options:
 - direction: positive
   target: 244715
   target_year: 2026
-progress_status: moderate_progress
 ---

--- a/meta/9-1-1.md
+++ b/meta/9-1-1.md
@@ -95,5 +95,4 @@ progress_calculation_options:
   base_year: 2015
   target_year: 2030
   limit: 100
-progress_status: deterioration
 ---

--- a/meta/9-2-1.md
+++ b/meta/9-2-1.md
@@ -57,5 +57,4 @@ source_geographical_coverage_1: Canada, provinces and territories
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
-progress_status: negligible_progress
 ---

--- a/meta/9-3-1.md
+++ b/meta/9-3-1.md
@@ -69,5 +69,4 @@ progress_calculation_options:
 - direction: positive
   target: 100
   target_year: 2030
-progress_status: substantial_progress
 ---

--- a/meta/9-4-1.md
+++ b/meta/9-4-1.md
@@ -56,5 +56,4 @@ auto_progress_calculation: true
 progress_calculation_options:
 - direction: positive
   limit: 100
-progress_status: negligible_progress
 ---

--- a/meta/9-5-1.md
+++ b/meta/9-5-1.md
@@ -59,5 +59,4 @@ source_geographical_coverage_1: Canada, provinces and territories
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-progress_status: substantial_progress
 ---

--- a/meta/9-6-1.md
+++ b/meta/9-6-1.md
@@ -73,5 +73,4 @@ progress_calculation_options:
   target: 37929
   base_year: 2015
   target_year: 2030
-progress_status: negligible_progress
 ---

--- a/meta/9-7-1.md
+++ b/meta/9-7-1.md
@@ -70,5 +70,4 @@ progress_calculation_options:
 - direction: positive
   target: 50
   target_year: 2030
-progress_status: target_achieved
 ---

--- a/meta/fr/13-1-1.md
+++ b/meta/fr/13-1-1.md
@@ -75,6 +75,5 @@ source_url_1: https://www.canada.ca/fr/environnement-changement-climatique/servi
 source_organisation_1: "Environnement et Changement climatique Canada"
 source_periodicity_1: Annuelle
 source_geographical_coverage_1: 'Canada, provinces et territoires'
-
 ---
 Cet indicateur correspond à l’indicateur du Programme des Indicateurs canadiens de durabilité de l'environnement <a href="https://www.canada.ca/fr/environnement-changement-climatique/services/indicateurs-environnementaux/emissions-gaz-effet-serre.html"> <em>Émissions de gaz à effet de serre</em></a>.

--- a/meta/fr/16-1-1.md
+++ b/meta/fr/16-1-1.md
@@ -51,5 +51,4 @@ source_url_1: 'https://doi.org/10.25318/4310005801-fra'
 source_organisation_1: "Statistique Canada"
 source_periodicity_1: "Occasionnelle"
 source_geographical_coverage_1: "Canada"
-
 ---

--- a/meta/fr/16-3-1.md
+++ b/meta/fr/16-3-1.md
@@ -46,5 +46,4 @@ source_url_1: https://doi.org/10.25318/3510000201-fra
 source_organisation_1: "Statistique Canada"
 source_periodicity_1: "Annuelle"
 source_geographical_coverage_1: Canada, provinces et territoires, régions métropolitaines de recensement
-
 ---

--- a/meta/fr/3-6-1.md
+++ b/meta/fr/3-6-1.md
@@ -55,5 +55,4 @@ source_url_3: 'https://doi.org/10.25318/1310088001-fra'
 source_organisation_3: Statistique Canada
 source_periodicity_3: Annuelle
 source_geographical_coverage_3: 'Canada (sauf territoires)'
-
 ---

--- a/meta/fr/8-2-1.md
+++ b/meta/fr/8-2-1.md
@@ -91,6 +91,5 @@ source_geographical_coverage_5: Canada, Région géographique du Canada
 # source_organisation_6: Statistique Canada
 # source_periodicity_6: Aux 5 ans
 # source_geographical_coverage_6: Canada, Région géographique du Canada, Province ou territoire
-
 ---
 

--- a/translations/en/status.yml
+++ b/translations/en/status.yml
@@ -6,6 +6,8 @@ deterioration: Deterioration
 # moderate_deterioration: Moderate deterioration
 # significant_deterioration: Substantial deterioration
 # substantial_deterioration: Substantial deterioration
-progress_not_available: Not available
-progress_header: <strong>Current progress status</strong>
+progress_not_available: Unable to assess
+# progress_header: <strong>Current progress status</strong>
+progress_status: <strong>Current progress status</strong>
 target_achieved: Target achieved
+not_available_manual: Not available

--- a/translations/fr/status.yml
+++ b/translations/fr/status.yml
@@ -14,14 +14,16 @@ disaggregation_status_notstarted: 'Non désagrégé'
 disaggregation_status_notapplicable: 'Hors champ'
 disaggregation_status_by_field: 'Désagrégation par % de champ'
 not_specified: Non spécifié
-progress_header: <strong>État du progrès actuel</strong>
+# progress_header: <strong>État du progrès actuel</strong>
+progress_status: <strong>État du progrès actuel</strong>
 target_achieved: Cible atteinte
 substantial_progress: Sur la bonne voie
 moderate_progress: Des progrès ont été réalisés, mais une accélération est nécessaire
-negligible_progress: Progrès limités
+# negligible_progress: Progrès limités
 limited_progress: Progrès limités
 deterioration: Détérioration
-progress_not_available: Pas disponible
-moderate_deterioration: Détérioration modérée
-significant_deterioration: Détérioration significative
-substantial_deterioration: Détérioration substantielle
+not_available_manual: Non disponible
+progress_not_available: Évaluation impossible
+# moderate_deterioration: Détérioration modérée
+# significant_deterioration: Détérioration significative
+# substantial_deterioration: Détérioration substantielle


### PR DESCRIPTION
- #624 
  - Set 6.4.1 and 13.1.1 to new status type: not_available_manual
  - Output not_available status as "Unable to assess / Évaluation impossible"
  - Output not_available_manual status as "Not available / Non disponible"
  - Clean up redundant progress statuses in metadata files.