### PR TITLE
Adjust zero targets

### DIFF
--- a/meta/3-12-1.md
+++ b/meta/3-12-1.md
@@ -48,6 +48,6 @@ source_geographical_coverage_1: Canada
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-  target: 0
+  target: 0.1
   target_year: 2030
 ---

--- a/meta/6-1-1.md
+++ b/meta/6-1-1.md
@@ -43,6 +43,6 @@ source_geographical_coverage_1: Communities on reserves south of the 60th parall
 auto_progress_calculation: true
 progress_calculation_options:
 - direction: negative
-  target: 0
+  target: 0.1
   target_year: 2030
 ---


### PR DESCRIPTION
Adjust zero targets for the progress measure from 0 to 0.1 (0.1 is a less overly aggressive replacement target than the default 0.001).